### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "wouter": "^3.3.5",
     "ws": "^8.18.0",
     "zod": "^3.23.8",
-    "zod-validation-error": "^3.4.0"
+    "zod-validation-error": "^3.4.0",
+    "express-rate-limit": "^7.5.0"
   },
   "devDependencies": {
     "@replit/vite-plugin-cartographer": "^0.0.11",

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -1,4 +1,5 @@
 import express, { type Express } from "express";
+import rateLimit from "express-rate-limit";
 import fs from "fs";
 import path, { dirname } from "path";
 import { fileURLToPath } from "url";
@@ -81,8 +82,14 @@ export function serveStatic(app: Express) {
 
   app.use(express.static(distPath));
 
+  // set up rate limiter: maximum of 100 requests per 15 minutes
+  const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // max 100 requests per windowMs
+  });
+
   // fall through to index.html if the file doesn't exist
-  app.use("*", (_req, res) => {
+  app.use("*", limiter, (_req, res) => {
     res.sendFile(path.resolve(distPath, "index.html"));
   });
 }


### PR DESCRIPTION
Potential fix for [https://github.com/AI-Dispatch/Habit-Tracker-College-Attendance-App/security/code-scanning/2](https://github.com/AI-Dispatch/Habit-Tracker-College-Attendance-App/security/code-scanning/2)

To fix the problem, we need to introduce rate limiting to the Express application. The best way to do this is by using the `express-rate-limit` package, which allows us to easily set up rate limiting middleware. We will configure the rate limiter to allow a maximum of 100 requests per 15 minutes and apply it to the relevant route handler.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `server/vite.ts` file.
3. Set up the rate limiter with the desired configuration.
4. Apply the rate limiter to the route handler that performs the file system access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
